### PR TITLE
Reword misleading warning message

### DIFF
--- a/src/aeplugin_rebar3.erl
+++ b/src/aeplugin_rebar3.erl
@@ -70,6 +70,9 @@ to_list(Dir, Type, Files) ->
                           TypeIndex = string:str(Split, [Type]),
                           Path = filename:join(lists:reverse(lists:sublist(Split, TypeIndex))),
                           {true, {filename:join([Dir, Path]), Bin}};
+                        {error, eisdir} ->
+                          rebar_api:warn("Skipping empty dir (~s)", [File]),
+                          false;
                         {error, Reason} ->
                           rebar_api:warn("Can't read file: ~p", [Reason]),
                           false


### PR DESCRIPTION
A misleading warning message appeared when the archive building process encountered an empty directory (the zip lib doesn't support adding those):

> ===> Can't read file: eisdir

This is changed to:

> ===> Skipping empty dir (/[...]/_build/default/lib/aesophia/priv/stdlib)
