### PR TITLE
Fix pack list

### DIFF
--- a/src/aeplugin_rebar3.erl
+++ b/src/aeplugin_rebar3.erl
@@ -57,8 +57,8 @@ files(MainApp, Deps, State) ->
 app_files(App) ->
     [Name, Vsn, EbinDir, PrivDir] = [rebar_app_info:F(App) || F <- [name, vsn, ebin_dir, priv_dir]],
     Dir = to_string([Name, "-", Vsn]),
-    Priv = filelib:wildcard(filename:join(PrivDir, "**/*"), file),
-    Ebin = filelib:wildcard(filename:join(EbinDir, "*.{beam,app}"), file),
+    Priv = files_in_dir(PrivDir),
+    Ebin = files_in_dir(EbinDir),
     to_list(Dir, "ebin", Ebin)
         ++ to_list(Dir, "priv", Priv).
 
@@ -70,14 +70,16 @@ to_list(Dir, Type, Files) ->
                           TypeIndex = string:str(Split, [Type]),
                           Path = filename:join(lists:reverse(lists:sublist(Split, TypeIndex))),
                           {true, {filename:join([Dir, Path]), Bin}};
-                        {error, eisdir} ->
-                          rebar_api:warn("Skipping empty dir (~s)", [File]),
-                          false;
                         {error, Reason} ->
                           rebar_api:warn("Can't read file: ~p", [Reason]),
                           false
                       end
                   end, Files).
+
+files_in_dir(Dir) ->
+    lists:reverse(
+      filelib:fold_files(Dir, ".*", true,
+                         fun(F, Acc) -> [F|Acc] end, [])).
 
 to_string(List) ->
   binary_to_list(iolist_to_binary(List)).

--- a/src/aeplugin_rebar3.erl
+++ b/src/aeplugin_rebar3.erl
@@ -98,7 +98,8 @@ ext_deps(App, State) ->
             ExtDeps = lists:foldr(
                         fun(A, Acc) ->
                                 Name = element(1, A),
-                                case lists:keymember(Name, 1, AeDeps) of
+                                case lists:keymember(Name, 1, AeDeps)
+                                    orelse lists:member(Name, Acc) of
                                     true ->
                                         Acc;
                                     false ->

--- a/src/aeplugin_rebar3.erl
+++ b/src/aeplugin_rebar3.erl
@@ -70,6 +70,9 @@ to_list(Dir, Type, Files) ->
                           TypeIndex = string:str(Split, [Type]),
                           Path = filename:join(lists:reverse(lists:sublist(Split, TypeIndex))),
                           {true, {filename:join([Dir, Path]), Bin}};
+                        {error, eisdir} ->
+                          rebar_api:warn("Skipping empty dir (~s)", [File]),
+                          false;
                         {error, Reason} ->
                           rebar_api:warn("Can't read file: ~p", [Reason]),
                           false


### PR DESCRIPTION
When packing the plugin archive, there could be warnings about `eisdir` errors.
The problem was that the code collecting files for the zip archive would include also directory names, which cannot be added by themselves to the zip file.

This PR uses a different strategy (`filelib:fold_files/5`), which only looks at files.
Also, duplicates in the external deps list are avoided. This didn't appear to cause any problems, other than looking bad.